### PR TITLE
Scaffold Forge 1.20.1 PLN economy core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,29 @@
+buildscript {
+    repositories {
+        maven { url = 'https://maven.minecraftforge.net' }
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'net.minecraftforge.gradle:ForgeGradle:6.0.+'
+    }
+}
+
+apply plugin: 'net.minecraftforge.gradle'
+apply plugin: 'eclipse'
+
+version = '1.0.0'
+group = 'pl.plneconomy'
+
+java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+
+minecraft {
+    mappings channel: 'official', version: '1.20.1'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    minecraft 'net.minecraftforge:forge:1.20.1-47.4.10'
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'plneconomy'

--- a/src/main/java/pl/plneconomy/PLNEconomyMod.java
+++ b/src/main/java/pl/plneconomy/PLNEconomyMod.java
@@ -1,0 +1,16 @@
+package pl.plneconomy;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import pl.plneconomy.item.ModItems;
+
+@Mod(PLNEconomyMod.MOD_ID)
+public class PLNEconomyMod {
+    public static final String MOD_ID = "plneconomy";
+
+    public PLNEconomyMod() {
+        IEventBus eventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        ModItems.ITEMS.register(eventBus);
+    }
+}

--- a/src/main/java/pl/plneconomy/data/BankData.java
+++ b/src/main/java/pl/plneconomy/data/BankData.java
@@ -1,0 +1,72 @@
+package pl.plneconomy.data;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.saveddata.SavedData;
+
+public class BankData extends SavedData {
+    public static final String DATA_NAME = "plneconomy";
+    private final Map<UUID, Long> balances = new HashMap<>();
+
+    public static BankData get(ServerLevel level) {
+        return level.getDataStorage().computeIfAbsent(BankData::load, BankData::new, DATA_NAME);
+    }
+
+    public long getBalance(UUID uuid) {
+        return balances.getOrDefault(uuid, 0L);
+    }
+
+    public void deposit(UUID uuid, long grosze) {
+        balances.put(uuid, getBalance(uuid) + grosze);
+        setDirty();
+    }
+
+    public boolean withdraw(UUID uuid, long grosze) {
+        if (!hasSufficientBalance(uuid, grosze)) {
+            return false;
+        }
+        balances.put(uuid, getBalance(uuid) - grosze);
+        setDirty();
+        return true;
+    }
+
+    public boolean transfer(UUID from, UUID to, long grosze) {
+        if (!withdraw(from, grosze)) {
+            return false;
+        }
+        deposit(to, grosze);
+        return true;
+    }
+
+    public boolean hasSufficientBalance(UUID uuid, long grosze) {
+        return getBalance(uuid) >= grosze;
+    }
+
+    @Override
+    public CompoundTag save(CompoundTag tag) {
+        ListTag listTag = new ListTag();
+        balances.forEach((uuid, amount) -> {
+            CompoundTag row = new CompoundTag();
+            row.putUUID("uuid", uuid);
+            row.putLong("balance", amount);
+            listTag.add(row);
+        });
+        tag.put("balances", listTag);
+        return tag;
+    }
+
+    public static BankData load(CompoundTag tag) {
+        BankData data = new BankData();
+        ListTag listTag = tag.getList("balances", Tag.TAG_COMPOUND);
+        for (Tag value : listTag) {
+            CompoundTag row = (CompoundTag) value;
+            data.balances.put(row.getUUID("uuid"), row.getLong("balance"));
+        }
+        return data;
+    }
+}

--- a/src/main/java/pl/plneconomy/item/BanknoteItem.java
+++ b/src/main/java/pl/plneconomy/item/BanknoteItem.java
@@ -1,0 +1,36 @@
+package pl.plneconomy.item;
+
+import java.util.List;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+public class BanknoteItem extends Item {
+    private final Denomination denomination;
+
+    public BanknoteItem(Denomination denomination) {
+        super(new Item.Properties().stacksTo(64));
+        this.denomination = denomination;
+    }
+
+    @Override
+    public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {
+        tooltip.add(Component.literal("Wartość: " + Denomination.fmt(denomination.grosze())).withStyle(ChatFormatting.GOLD));
+        if (stack.getCount() > 1) {
+            tooltip.add(Component.literal("Łącznie: " + Denomination.fmt(denomination.grosze() * stack.getCount()))
+                    .withStyle(ChatFormatting.YELLOW));
+        }
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
+        return InteractionResultHolder.pass(player.getItemInHand(hand));
+    }
+}

--- a/src/main/java/pl/plneconomy/item/Denomination.java
+++ b/src/main/java/pl/plneconomy/item/Denomination.java
@@ -1,0 +1,59 @@
+package pl.plneconomy.item;
+
+import java.util.Arrays;
+
+public enum Denomination {
+    GR_1(1, "1gr"),
+    GR_2(2, "2gr"),
+    GR_5(5, "5gr"),
+    GR_10(10, "10gr"),
+    GR_20(20, "20gr"),
+    GR_50(50, "50gr"),
+    ZL_1(100, "1zl"),
+    ZL_2(200, "2zl"),
+    ZL_5(500, "5zl"),
+    ZL_10(1000, "10zl"),
+    ZL_20(2000, "20zl"),
+    ZL_50(5000, "50zl"),
+    ZL_100(10000, "100zl"),
+    ZL_200(20000, "200zl"),
+    ZL_500(50000, "500zl");
+
+    private final long grosze;
+    private final String key;
+
+    Denomination(long grosze, String key) {
+        this.grosze = grosze;
+        this.key = key;
+    }
+
+    public long grosze() {
+        return grosze;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public static String fmt(long grosze) {
+        long zl = grosze / 100;
+        long gr = Math.abs(grosze % 100);
+        return String.format("%d,%02d zł", zl, gr);
+    }
+
+    public static long parse(String value) {
+        String cleaned = value.trim().replace("zł", "").replace(" ", "").replace(',', '.');
+        if (cleaned.isBlank()) {
+            throw new IllegalArgumentException("Empty amount");
+        }
+        String[] split = cleaned.split("\\.");
+        long zl = Long.parseLong(split[0]);
+        long gr = split.length > 1 ? Long.parseLong((split[1] + "00").substring(0, 2)) : 0;
+        return zl * 100 + (zl < 0 ? -gr : gr);
+    }
+
+    public static Denomination byKey(String key) {
+        return Arrays.stream(values()).filter(d -> d.key.equals(key)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown denomination: " + key));
+    }
+}

--- a/src/main/java/pl/plneconomy/item/ModItems.java
+++ b/src/main/java/pl/plneconomy/item/ModItems.java
@@ -1,0 +1,23 @@
+package pl.plneconomy.item;
+
+import java.util.EnumMap;
+import java.util.Map;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import pl.plneconomy.PLNEconomyMod;
+
+public final class ModItems {
+    public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, PLNEconomyMod.MOD_ID);
+    public static final Map<Denomination, RegistryObject<BanknoteItem>> BY_DENOM = new EnumMap<>(Denomination.class);
+
+    static {
+        for (Denomination denomination : Denomination.values()) {
+            BY_DENOM.put(denomination, ITEMS.register(denomination.key(), () -> new BanknoteItem(denomination)));
+        }
+    }
+
+    private ModItems() {
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,11 @@
+modLoader="javafml"
+loaderVersion="[47,)"
+license="MIT"
+
+[[mods]]
+modId="plneconomy"
+version="1.0.0"
+displayName="PLN Economy"
+description='''
+PLN economy system scaffold.
+'''


### PR DESCRIPTION
### Motivation
- Stworzyć podstawowy szkielet moda zgodny z wymaganiami (Forge `1.20.1-47.4.10`, Java 17, Gradle 8.8) jako fundament dla systemu ekonomicznego PLN.
- Zapewnić reprezentację waluty opartą wyłącznie o `long` (grosze) oraz bazowe itemy i trwałe dane świata do dalszej integracji funkcji (ATM, telefon, SMS, sklepy, prace, tickery).

### Description
- Dodano konfigurację Gradle opartą o `buildscript {}` oraz pliki `build.gradle`, `settings.gradle` i `gradle/wrapper/gradle-wrapper.properties` ustawione pod Java 17 i Forge `1.20.1-47.4.10`.
- Dodano punkt wejścia moda `pl.plneconomy.PLNEconomyMod` rejestrujący `DeferredRegister` itemów w konstruktorze moda.
- Zaimplementowano `Denomination` enum z wartościami w groszach, helperami `fmt(long)` oraz `parse(String)`, oraz `BanknoteItem extends Item` z maksymalnym stosem 64 i tooltipami pokazującymi `Wartość` i `Łącznie`.
- Dodano `ModItems` z `DeferredRegister` i `EnumMap<Denomination, RegistryObject<BanknoteItem>>` rejestrującą automatycznie wszystkie 15 nominałów oraz `BankData extends SavedData` z metodami `deposit`, `withdraw`, `transfer`, `hasSufficientBalance` i zapisem/odczytem NBT.
- Dodano podstawowy `mods.toml` dla modu `plneconomy`.

### Testing
- Zatwierdzono zmiany do repozytorium za pomocą commita i sprawdzono porządek repo z `git status --short`, co zakończyło się bez błędów.
- Nie uruchamiano kompilacji ani zautomatyzowanych testów budujących projekt w tym PR; dalsze testy integracyjne/kompilacyjne planowane przy dodawaniu funkcji sieciowych i UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df7be1bd8832e854905bafe2dbec5)